### PR TITLE
Jellyfin Library Locator

### DIFF
--- a/librarylocator.py
+++ b/librarylocator.py
@@ -1,0 +1,44 @@
+import os 
+import pathlib
+from operator import itemgetter
+
+#Name your current Jfin playlist location here. The default location for Windows installations is listed below
+rootdir = r'C:\ProgramData\Jellyfin\Server\root\default'
+#Name your new paths here. If the root dir of your libraries currently sits in Windows style "C:/Media", and you want it to end up in Unix style "media/", then [C:/Media, /media]
+#If you have multiple locations for your libraries, you can specify individual locations or migrate them all together. Up to you. 
+newpathlist = [["E:", "/media"], ["G:", "/media"], ["%AppDataPath%", "/data/data"]]
+
+def main():
+    pathdictlist = []
+    for root, dirs, files in os.walk(rootdir):
+        for file in files:
+            filename, fileext = os.path.splitext(file)
+            if fileext == ".mblink":
+                with open(os.path.join(root, file)) as f:
+                    wosix = ((((pathlib.PurePosixPath(repr(f.read()))).as_posix()).replace('\\','/')).replace("//", "/")).replace("'","")
+                    linkdepthcount = wosix.count('/')
+                    for pathlist in newpathlist:
+                        if wosix.startswith(pathlist[0]): 
+                            newpath = wosix.replace(pathlist[0], pathlist[1])
+                    pathdict = {'wpath': wosix, 'lpath': newpath, 'depth': linkdepthcount}
+                    if pathdict not in pathdictlist:
+                        pathdictlist.append(pathdict)      
+    
+    newlist = sorted(pathdictlist, key=itemgetter('depth'), reverse=True)
+    
+    print("\n\n---BEGINNING path_replacements LIBRARY LOOKUP---\n\n")
+    for dict in newlist:
+        try: 
+            print('"' + dict.get('wpath') + '" : "' + dict.get('lpath') + '",')
+        except UnicodeEncodeError:
+            print("---LIBRARY PASSED DUE TO UNICODE ERROR---")
+    
+    print("\n\n---BEGINNING fs_path_replacements REVERSE LIBRARY LOOKUP---\n\n")
+    for dict in newlist:
+        try: 
+            print('"' + dict.get('lpath') + '" : "' + dict.get('wpath') + '",')
+        except UnicodeEncodeError:
+            print("---LIBRARY PASSED DUE TO UNICODE ERROR---")
+    
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Created a tool to allow multiple .mblink playlists to be updated to the new format. I had near 100 playlists in Jellyfin at the time of migration so this script became a necessity for me. These playlists can reference multiple locations thanks to newpathlist, but this will need to be adjusted for each user's environment. This will walk through each file under rootdir and then examine if the file extension (fileext) is .mblink. If so, pathing within the .mblink file is changed from Windows style \\ to Posix / in temporary memory. This then prints off the results from memory, so these can be used under path_replacements and fs_path_replacements in the main script jellyfin_migrator.py via a simple user copy and paste of the text in the terminal. 

I considered adding this as a function in jellyfin_migrator.py but decided against it as I had to run the script a few times to get past issues with Unicode errors that arose from alternate languages. This granular control of getting the output from this script and then inserting it into the main script can help the user to detect if these errors exist, and see if they've properly set up their pathing in newpathlist.